### PR TITLE
As per Python3.9.0, threading does no longer support is.Alive(), repl…

### DIFF
--- a/Includes/simple_multitasking/simple_multitasking_example.py
+++ b/Includes/simple_multitasking/simple_multitasking_example.py
@@ -38,7 +38,7 @@ else:
 	unhandled_threads = [t for t in threads if not t.isHandled()]
 	while len(unhandled_threads) != 0:
 		# Loop through processed threads
-		for unactive_thread in [a for a in unhandled_threads if not a.isAlive()]:
+		for unactive_thread in [a for a in unhandled_threads if not a.is_alive()]:
 			print(unactive_thread.getValue())
 			total_time += unactive_thread.getTime()
 		unhandled_threads = [t for t in threads if not t.isHandled()]


### PR DESCRIPTION
As per Python3.9.0, threading does no longer supports the method for `is.Alive() `and has been replaced by `is_alive()`
![128440847_697559344237263_4568354060807502334_n](https://user-images.githubusercontent.com/37149330/101098065-97b3c280-35c2-11eb-81bd-b0d47f2cf48f.png)
